### PR TITLE
Update code scanning config to use standard CodeQL Go pack

### DIFF
--- a/.github/codeql.yml
+++ b/.github/codeql.yml
@@ -3,4 +3,5 @@ name: "My CodeQL config"
 
 queries:
   - uses: security-and-quality
-  - uses: github/codeql-go/ql/src/experimental@main
+packs:
+  - codeql/go-queries:experimental

--- a/.github/codeql.yml
+++ b/.github/codeql.yml
@@ -4,4 +4,4 @@ name: "My CodeQL config"
 queries:
   - uses: security-and-quality
 packs:
-  - codeql/go-queries:experimental
+  - 'codeql/go-queries:experimental'


### PR DESCRIPTION
The `codeql-go` repository is deprecated. See https://github.com/github/codeql-go/issues/741 for details.
Refer instead to the same query folder, but within the `codeql/go-queries` query pack that is bundled by default with CodeQL on Actions.